### PR TITLE
Allow Rails 6.1 with Ruby 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
 .DS_Store
+*.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - db/schema.rb
     - spec/dummy/db/schema.rb
   NewCops: enable
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.0
 
 plugins:
   - rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    counter_cache_update (0.0.7)
-      rails (~> 7.1.0)
+    counter_cache_update (0.0.8)
+      rails (>= 6.1, < 8.0)
       service_pattern (>= 1.0.0)
 
 GEM

--- a/counter_cache_update.gemspec
+++ b/counter_cache_update.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |s|
   s.summary = "Scans all your models and updates all counter caches with optimised SQL."
   s.description = "Scans all your models and updates all counter caches with optimised SQL."
   s.license = "MIT"
-  s.required_ruby_version = ">= 3.3"
+  s.required_ruby_version = ">= 3.0"
   s.metadata["rubygems_mfa_required"] = "true"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 7.1.0"
+  s.add_dependency "rails", ">= 6.1", "< 8.0"
   s.add_dependency "service_pattern", ">= 1.0.0"
 end


### PR DESCRIPTION
## Summary
- loosen Rails dependency to include 6.1 while keeping Ruby 3+
- align RuboCop target Ruby to 3.0
- refresh lockfile for dependency bounds
- ignore built gem artifacts

## Testing
- bundle exec rspec
- bundle exec rubocop